### PR TITLE
feat: add 5 ep of keisanchu s1

### DIFF
--- a/docs/keisanchu/season1.md
+++ b/docs/keisanchu/season1.md
@@ -1,0 +1,54 @@
+---
+template: comment.html
+title: 22/7 计算中 - Season 1
+---
+
+!!! general inline end "22/7 计算中"
+
+	--------
+
+	<b>节目名称:</b> 22/7 計算中 season 1
+
+	--------
+	
+	<b>节目译名:</b> 22/7 计算中 第一季
+
+	--------
+	
+	<b>放送时间:</b> 周六 23:00-23:30(UTC+9)
+
+	--------
+
+	<b>放送期间:</b> 2018年7月7日~2019年12月28日
+
+	--------
+
+	<b>MC:</b> 三四郎(小宫浩信 ~~(妮可露推)~~ / 相田周二 ~~(miu的理解者)~~ )
+
+	--------
+
+	<b>节目状态:</b> 已完结
+
+	--------
+
+	<b>播放平台:</b> 东京MX/BS11
+
+	--------
+
+	<b>Staff:</b> <br />监督: 秋元伸介 <br />解说: 山盛由果 <br /> 构成: 町田裕章 <br /> 水野将良 <br /> 清山智之 <br /> 制片人: 工藤浩之<br />长尾真<br />坂本加恵<br />三浦绍<br />足立和纪
+
+	--------
+
+	<b>制作:</b> バズウェーブ合同会社
+
+## 各集列表
+
+| 集数 |    放送日    | 标题                     |                                                                 链接                                                                 |
+|:--:|:---------:|------------------------|:----------------------------------------------------------------------------------------------------------------------------------:|
+| 1  | 2018.7.7  | 22/7成员自我展示视频比赛（上）      | [中字](https://www.bilibili.com/video/BV16s411n7Xo/?share_source=copy_web&vd_source=53eb07c91966442a76aa1bebf575fd26){target=_blank} |
+| 2  | 2018.7.14 | 22/7成员自我展示视频比赛（下）      | [中字](https://www.bilibili.com/video/BV1ks41177P3/?share_source=copy_web&vd_source=53eb07c91966442a76aa1bebf575fd26){target=_blank} |
+| 3  | 2018.7.21 | 尖叫系报告大赛（上）             | [中字](https://www.bilibili.com/video/BV1ms411c7rs/?share_source=copy_web&vd_source=53eb07c91966442a76aa1bebf575fd26){target=_blank} |
+| 4  | 2018.7.28 | 尖叫系报告大赛（下）             | [中字](https://www.bilibili.com/video/BV1SW411R7Gg/?share_source=copy_web&vd_source=53eb07c91966442a76aa1bebf575fd26){target=_blank} |
+| 5  | 2018.8.4  | ANIME EXPO 2018潜入报告（上） | [中字](https://www.bilibili.com/video/BV1VW411D7u3/?share_source=copy_web&vd_source=53eb07c91966442a76aa1bebf575fd26){target=_blank} |
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ nav:
 
   - 计算中:
       - 简介: keisanchu/index.md
+      - Season1: keisanchu/season1.md
 
   - 检算中:
       - 简介: kensanchu/index.md


### PR DESCRIPTION
之前在群聊内看到有人希望现在的wiki能像之前老wiki一样，方便查询视频并跳转播放
目前先写了前 5 集作为模板示范，结构和链接格式这样行吗？有什么想法不？如果没问题我就继续填剩下的。
![template](https://github.com/user-attachments/assets/93e55c25-7c0e-4850-993f-fbad59af00b8)
