### PR TITLE
update the preview and MV in the album details

### DIFF
--- a/docs/songs/single/10th/index.md
+++ b/docs/songs/single/10th/index.md
@@ -129,4 +129,26 @@ template: comment.html
 
 总时长：24:17
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="156931154"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1954528815&bvid=BV1iC41177Zj&cid=1544493008&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1iC41177Zj){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=ey0LjN94cwg){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/11th/index.md
+++ b/docs/songs/single/11th/index.md
@@ -100,4 +100,26 @@ template: comment.html
 | 5.      | あやふやな世界観-off vocal ver.- |  |
 | 6.      | もう純情は邪魔なだけ-off vocal ver.- |  |
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="164859106"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1804570018&bvid=BV1Ab42187aa&cid=1544597156&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1Ab42187aa){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=87IzmBR3v4o){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/12th/index.md
+++ b/docs/songs/single/12th/index.md
@@ -121,4 +121,30 @@ template: comment.html
 | 5.      | 春雷の頃-off vocal ver.- |  |
 | 6.      | 世界中で歌おうぜ-off vocal ver.- |  |
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="191625699"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114796288542244&bvid=BV1153Uz4EXD&cid=30855989652&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1153Uz4EXD){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=HwOtrYzcVXo){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789074340884&bvid=BV1uL3uzWEnt&cid=30830757128&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1uL3uzWEnt){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=R54CPPzrAyQ){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/13th/index.md
+++ b/docs/songs/single/13th/index.md
@@ -147,4 +147,30 @@ YESとNOの間に是22/7的第13张单曲，也是动画《ATRI -My Dear Moments
 | 5.      | 佐藤さん-off vocal ver.- |  |
 | 6.      | 声優になりたくて-off vocal ver.- |  |
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="250333827"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789057628236&bvid=BV1ag3uzoEjA&cid=30830693500&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1ag3uzoEjA){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=t02p504QfAc){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789527328548&bvid=BV13J33zbE5W&cid=30830759106&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV13J33zbE5W){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=Nsq4lg5aeig){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/14th/index.md
+++ b/docs/songs/single/14th/index.md
@@ -125,4 +125,31 @@ template: comment.html
 | 2.      | ロックは死なない(dance video) | Katsuaki Ishii |  |
 | 3.      | 不遇職【鑑定士】が実は最強だった Non-Credit Ending Movie |  |  |
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="261761795"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789107893600&bvid=BV15K3uz8EJ2&cid=30830824561&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV15K3uz8EJ2){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=r-UKTpVMZfs){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789107893357&bvid=BV15K3uz8ELj&cid=30830887927&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV15K3uz8ELj){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=PzehIVO3O0Q){ .md-button .md-button--primary }
+
+
 <!-- gitalk -->

--- a/docs/songs/single/15th/index.md
+++ b/docs/songs/single/15th/index.md
@@ -145,4 +145,30 @@ template: comment.html
 | --------| ------------------------------------ | ------- |
 | 1.      | Making of Nagomi Saijo Graduation Memorial Photobook |  |
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="276451417"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789040787293&bvid=BV1gG3uzxEf1&cid=30830628052&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1gG3uzxEf1){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=NkmkyggvPns){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=114789107894951&bvid=BV15K3uz8EN4&cid=30830953466&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV15K3uz8EN4){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=mIZmSfvuLZM){ .md-button .md-button--primary }
+    
 <!-- gitalk -->

--- a/docs/songs/single/2nd/index.md
+++ b/docs/songs/single/2nd/index.md
@@ -109,7 +109,7 @@ template: comment.html
 ### 网易云音乐
 
 <meting-js
-        id="待补"
+        id="38273111"
         server="netease"
         order="list"
         type="album"
@@ -121,17 +121,12 @@ template: comment.html
         >
 </meting-js>
 
-### Apple Music
-
-待补
 
 ## 视频
 
 === "Music Video"
-    待补
+    <iframe src="https://player.bilibili.com/player.html?aid=543026844&bvid=BV1Ti4y157Qo&cid=265042201&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1Ti4y157Qo){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=79qPHlqistg){ .md-button .md-button--primary }
 
-## 下载
 
-待补
-
-<!-- gitalk -->

--- a/docs/songs/single/3rd/index.md
+++ b/docs/songs/single/3rd/index.md
@@ -114,4 +114,29 @@ template: comment.html
 
 总时长：28:04
 
-<!-- gitalk -->
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="72382727"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+## 视频
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=458124211&bvid=BV1q5411G7nj&cid=369481376&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1q5411G7nj){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=DB98rK3xnbU){ .md-button .md-button--primary }
+
+
+

--- a/docs/songs/single/4th/index.md
+++ b/docs/songs/single/4th/index.md
@@ -112,4 +112,28 @@ template: comment.html
 
 总时长：26:18
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="81064731"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+## 视频
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=306237943&bvid=BV1VA41197MZ&cid=922105156&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1VA41197MZ){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=frO6XqKCeZ0){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/5th/index.md
+++ b/docs/songs/single/5th/index.md
@@ -113,4 +113,29 @@ template: comment.html
 
 总时长：26:25
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="85790526"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+## 视频
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1854575035&bvid=BV1Ms421P7L4&cid=1544109149&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1Ms421P7L4){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=J9JQrg1ugsk){ .md-button .md-button--primary }
+
+
 <!-- gitalk -->

--- a/docs/songs/single/6th/index.md
+++ b/docs/songs/single/6th/index.md
@@ -109,4 +109,30 @@ template: comment.html
 
 总时长：27:13
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="95393869"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1654708835&bvid=BV1H7421f75F&cid=1544124730&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1H7421f75F){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=Hl1SvbaI0ls){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1854683909&bvid=BV1fs421c7BS&cid=1544128590&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1fs421c7BS){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=PO78JmxBIbM){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/7th/index.md
+++ b/docs/songs/single/7th/index.md
@@ -129,4 +129,26 @@ template: comment.html
 
 总时长：24:23
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="123556791"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1404666374&bvid=BV1jr421j7PH&cid=1544135359&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1jr421j7PH){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=wfhOmvXL0i0){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/8th/index.md
+++ b/docs/songs/single/8th/index.md
@@ -129,4 +129,26 @@ template: comment.html
 
 总时长：22:51
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="135680408"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1454521479&bvid=BV1Gi421X7Hv&cid=1544438909&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV1Gi421X7Hv){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=0G13oI9rhcc){ .md-button .md-button--primary }
+
 <!-- gitalk -->

--- a/docs/songs/single/9th/index.md
+++ b/docs/songs/single/9th/index.md
@@ -129,4 +129,30 @@ template: comment.html
 
 总时长：28:21
 
+## 试听
+
+### 网易云音乐
+
+<meting-js
+        id="147772402"
+        server="netease"
+        order="list"
+        type="album"
+        list-olded="true"
+        autoplay="false"
+        mutex="true"
+        volume=0.5
+        theme="#0091eb"
+        >
+</meting-js>
+
+=== "Music Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1104746149&bvid=BV13w4m1D7y1&cid=1544448316&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV13w4m1D7y1){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=Mh9E1iZxoHs){ .md-button .md-button--primary }
+=== "Dance Video"
+    <iframe src="https://player.bilibili.com/player.html?aid=1054747456&bvid=BV18H4y1u7kB&cid=1544512054&p=1&autoplay=0" autoplay="0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" width="100%" height="720"> </iframe>
+    [:pack-bili-tv: 前往bilibili观看](https://www.bilibili.com/video/BV18H4y1u7kB){ .md-button .md-button--primary }
+    [:fontawesome-brands-youtube: 前往YouTube观看](https://www.youtube.com/watch?v=UlqWsGKCius){ .md-button .md-button--primary }
+
 <!-- gitalk -->


### PR DESCRIPTION
补充了各单 index 页面中的网易云试听和 MV 观看内容，暂时没有添加 Apple Music 试听。

感觉两个试听入口有点重复，后续也许可以考虑改成能听完整版的入口（不过这点看你怎么考虑）。之后会慢慢补每首歌的详情页，歌曲详情页里的网易云试听我暂时先不加。